### PR TITLE
fix: handle empty bodies and error responses

### DIFF
--- a/rpc/error.go
+++ b/rpc/error.go
@@ -13,7 +13,9 @@ func (rpc *Handler[Req, Res]) Error() rf.ErrorHandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request, err error) {
 		yaelErr, ok := err.(*yael.E)
 		if !ok {
-			yaelErr = yael.New("unknown")
+			unknown := yael.New("unknown")
+			unknownJSON, _ := json.Marshal(unknown)
+			result(w, string(unknownJSON), http.StatusInternalServerError, &defaultContentType)
 			return
 		}
 

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -1,7 +1,6 @@
 package rpc
 
 import (
-	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -18,17 +17,17 @@ func (h *Handler[Req, Res]) Handle() rf.HandlerFunc {
 			return err
 		}
 
+		r.Body.Close()
+
 		if err := validateBody(body, h.schema); err != nil {
 			return err
 		}
 
-		r.Body.Close()
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
-
 		var req Req
-		err = json.NewDecoder(r.Body).Decode(&req)
-		if err != nil {
-			return err
+		if len(body) > 0 {
+			if err = json.Unmarshal(body, &req); err != nil {
+				return err
+			}
 		}
 
 		res, err := h.fn(r.Context(), req)

--- a/rpc/handler_test.go
+++ b/rpc/handler_test.go
@@ -1,0 +1,106 @@
+package rpc_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/snicol/rf/rpc"
+)
+
+type testReq struct {
+	Name string `json:"name"`
+}
+
+type testRes struct {
+	Greeting string `json:"greeting"`
+}
+
+func newEchoHandler() *rpc.Handler[testReq, testRes] {
+	return rpc.NewHandler(func(_ context.Context, req testReq) (testRes, error) {
+		return testRes{Greeting: "hello " + req.Name}, nil
+	}, nil)
+}
+
+func TestHandle_WithBody(t *testing.T) {
+	h := newEchoHandler()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"world"}`))
+	w := httptest.NewRecorder()
+
+	if err := h.Handle()(w, req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "hello world") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestHandle_EmptyBody(t *testing.T) {
+	h := newEchoHandler()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(""))
+	w := httptest.NewRecorder()
+
+	// Empty body must not return EOF — zero-value Req should be used.
+	if err := h.Handle()(w, req); err != nil {
+		t.Fatalf("unexpected error for empty body: %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandle_InvalidJSON(t *testing.T) {
+	h := newEchoHandler()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{bad json`))
+	w := httptest.NewRecorder()
+
+	if err := h.Handle()(w, req); err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestHandle_MultipartJSONIsRejected(t *testing.T) {
+	h := newEchoHandler()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"foo"}{"name":"bar"}`))
+	w := httptest.NewRecorder()
+
+	if err := h.Handle()(w, req); err == nil {
+		t.Fatal("expected error for multipart JSON body, got nil")
+	}
+}
+
+func TestError_NonYaelErrorIs500(t *testing.T) {
+	h := newEchoHandler()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	w := httptest.NewRecorder()
+
+	h.Error()(w, req, errors.New("some internal error"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "unknown") {
+		t.Fatalf("expected 'unknown' in body, got: %s", body)
+	}
+}
+
+func TestHandle_ZeroResponseIs204(t *testing.T) {
+	h := rpc.NewHandler(func(_ context.Context, _ testReq) (testRes, error) {
+		return testRes{}, nil
+	}, nil)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+
+	if err := h.Handle()(w, req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
Fixes:

* If an error assertion doesn't evaluate to `yael.E`, then a correct `unknown` response is written.
* Empty request bodies will no longer be parsed.