### PR TITLE
feat: add panic recoverer middleware

### DIFF
--- a/example/basic/server.go
+++ b/example/basic/server.go
@@ -47,6 +47,7 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
 	g := rf.NewHandlerGroup(nil, middleware.Logger(logger))
+	g := rf.NewHandlerGroup(nil, middleware.Logger(logger), middleware.Recover(logger))
 
 	mux.Handle("/example", g.Use(basic.NewHandler(basic.GetParams, Example)))
 	mux.Handle("/json_echo", g.Use(basic.NewHandler(basic.GetParams, JSONEchoExample)))

--- a/example/rpc/server.go
+++ b/example/rpc/server.go
@@ -49,6 +49,7 @@ func example_mux() {
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	g := rf.NewHandlerGroup(rpc.DefaultMiddleware(), middleware.Logger(logger))
+	g := rf.NewHandlerGroup(rpc.DefaultMiddleware(), middleware.Logger(logger), middleware.Recover(logger))
 
 	mux.Handle("/example", g.Use(rpc.NewHandler(Example, schema)))
 
@@ -63,6 +64,7 @@ func main() {
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	g := rf.NewHandlerGroup(rpc.DefaultMiddleware(), middleware.Logger(logger))
+	g := rf.NewHandlerGroup(rpc.DefaultMiddleware(), middleware.Logger(logger), middleware.Recover(logger))
 
 	r.Post("/example", g.Use(rpc.NewHandler(Example, schema)))
 

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+	"time"
+
+	"github.com/snicol/rf"
+)
+
+func Recover(logger *slog.Logger) rf.MiddlewareFunc {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return func(next rf.HandlerFunc) rf.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) (retErr error) {
+			start := time.Now()
+			defer func() {
+				p := recover()
+				if p == nil {
+					return
+				}
+
+				logger.ErrorContext(r.Context(), "panic recovered",
+					slog.String("http_method", r.Method),
+					slog.String("http_path", r.URL.Path),
+					slog.Int64("req_duration_us", time.Since(start).Microseconds()),
+					slog.Int("http_status_code", http.StatusInternalServerError),
+					slog.String("panic", fmt.Sprint(p)),
+					slog.String("stack_trace", string(debug.Stack())),
+				)
+
+				w.WriteHeader(http.StatusInternalServerError)
+				retErr = nil
+			}()
+			return next(w, r)
+		}
+	}
+}


### PR DESCRIPTION
Adds a panic recoverer middleware to recover panics and log them with the same semantic log attributes as the logger middleware.