### PR TITLE
ci: harden CodeQL workflow with pinned SHAs and least privilege

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: '42 23 * * 4'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -29,14 +32,11 @@ jobs:
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     permissions:
-      # required for all workflows
+      # required to upload CodeQL results
       security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
+      # required by the actions language analysis to read workflow run data
       actions: read
+      # required to check out the repository
       contents: read
 
     strategy:
@@ -56,8 +56,13 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +72,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -96,6 +101,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Hardens the CodeQL workflow GitHub added to `main` when advanced setup was enabled, keeping its v4 / actions+go structure.

## Changes
- Top-level `permissions: contents: read` (default-deny the `GITHUB_TOKEN`)
- Least-privilege job permissions; dropped unneeded `packages: read`
- Added `step-security/harden-runner` (egress-policy: audit)
- Pinned all actions to commit SHAs with version comments:
  - `actions/checkout` v4.3.1
  - `github/codeql-action/{init,analyze}` v4.36.2
  - `step-security/harden-runner` v2.19.4

## Follow-up
Once merged, resolve the conflict in #11 by taking `main`'s `codeql.yml` (this hardened version) and dropping the StepSecurity v3/go-only one; the rest of #11 merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)